### PR TITLE
Overlap fix

### DIFF
--- a/src/picker/picker.js
+++ b/src/picker/picker.js
@@ -287,7 +287,7 @@ export default {
       }
       if (this.isDragging) {
         this.correction(this.findIndexFromScroll(this.top))
-      } else {
+      } else if (this.isMouseDown) {
         this.handleClick(e)
       }
       this.start = null


### PR DESCRIPTION
Issue: whenever an html element (e.g. dropdown, select) overlaps this one, clicking an option in dropdown/select is also triggering the picker to change.